### PR TITLE
Remove dead code from __init__

### DIFF
--- a/elasticmodels/__init__.py
+++ b/elasticmodels/__init__.py
@@ -1,7 +1,6 @@
 # these are just convenience imports
 from .indexes import Index, suspended_updates  # noqa
 from .receivers import update_indexes, delete_from_indexes  # noqa
-from .runner import SearchRunner, ESTestCase  # noqa
 from .fields import (  # noqa
     StringField,
     FloatField,


### PR DESCRIPTION
This code appears to be unused and was causing problems when I was trying to run EASA. Feel free to merge or close this pull request if necessary.